### PR TITLE
remove the placeholder on click

### DIFF
--- a/jquery.agecheck.js
+++ b/jquery.agecheck.js
@@ -87,6 +87,10 @@
                     _this.reCenter($('.ac-container'));
                     $('.ac-container').css({opacity: 1})
                 });
+                
+                $(".ac-container .day, .ac-container .year").focus(function(){
+                   $(this).removeAttr('placeholder');
+                });
             }, 
             setAge : function(){
                 _this.age = '';                 


### PR DESCRIPTION
seems like a helpful UI adjustment so users know they have to enter numeric values in these boxes
