### PR TITLE
Removes $(window).scroll considerations

### DIFF
--- a/jquery.agecheck.js
+++ b/jquery.agecheck.js
@@ -56,10 +56,8 @@
                 setTimeout(function(){$('.ac-container .errors').html(html)},200);
             },
             reCenter : function (b){
-                b.css("top", Math.max(0, (($(window).height() - (b.outerHeight() + 150)) / 2) + 
-                                            $(window).scrollTop()) + "px");
-                b.css("left", Math.max(0, (($(window).width() - b.outerWidth()) / 2) + 
-                                            $(window).scrollLeft()) + "px");
+                b.css("top", Math.max(0, (($(window).height() - (b.outerHeight() + 150)) / 2)) + "px");
+                b.css("left", Math.max(0, (($(window).width() - b.outerWidth()) / 2)) + "px");
             }, 
             buildHtml : function(){
             


### PR DESCRIPTION
Since styling of container is set to use fixed positioning, taking the window scroll distances into account could cause the age-check container to be unaccessible by the user. An unaccessible dialog can happen if a page's content is long in content and the user managed to scroll before the $(document).ready events fire.