### PR TITLE
Add package.json to allow npm publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ nbproject/private/private.xml
 nbproject/project.xml
 nbproject/project.properties
 /nbproject/private/
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "age-check",
+  "version": "1.0.0",
+  "description": "jQuery plugin to verify if user is old enough to enter site",
+  "main": "jquery.agecheck.js",
+  "repository": "https://github.com/michaelsoriano/age-check",
+  "author": "Michael Soriano",
+  "license": "GPL-3.0",
+  "dependencies": {
+    "jquery": "^3.2.1"
+  }
+}


### PR DESCRIPTION
#### What?

Adds a package.json file to the project so it can be published to npm as a module. This will make it easier to install for some developers. It also allows support for using npm modules such as eslint to enforce javascript styleguides.

#### How to test

`git clone` and run npm install. This should run a local jquery install as that is the only listed dependency. 