### PR TITLE
Add config for storage backend: sessionStorage or localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # age-check
 
-A simple plugin that verifies if a user is old enough to enter your site. You can easily customize the plugin with options and it uses sessionStorage to keep from popping up again. The modal box is responsive and is uses an external CSS for easy styling.
+A simple plugin that verifies if a user is old enough to enter your site.
+
+You can easily customize the plugin with options and it uses sessionStorage
+(or localStorage) to keep from popping up again.
+
+The modal box is responsive and uses an external CSS for easy styling.
 
 ## Usage
 
@@ -15,6 +20,7 @@ Add inside document ready: $.ageCheck()
 - successMsg {header (Header on top of success message), body (text for success message)}
 - underAgeMsg (Message when user didn't pass age requirements)
 - errorMsg {invalidDay (message for invalid day entered), invalidYear (message for invalid year entered)}
+- storage (sessionStorage or localStorage, sessionStorage is the default)
 
 ## To Minify JS + CSS
 
@@ -28,7 +34,7 @@ Add inside document ready: $.ageCheck()
 
 Click http://michaelsoriano.com/jquery-plugin-check-user-age/ for instructions and options
 
-and 
+and
 
 Click https://cdn.rawgit.com/michaelsoriano/age-check/master/index.html for demo
 

--- a/src/jquery.agecheck.js
+++ b/src/jquery.agecheck.js
@@ -1,7 +1,7 @@
 /*
  * Plugin: ageCheck.js
  * Description: A simple plugin to verify user's age.
- * Uses sessionStorage API to store if user is verified.
+ * Uses sessionStorage/localStorage API to store if user is verified.
  * Options can be passed for easy customization.
  * Author: Michael Soriano
  * Author's website: http://michaelsoriano.com
@@ -24,9 +24,11 @@
       errorMsg: {
         invalidDay: 'Day is invalid or empty',
         invalidYear: 'Year is invalid or empty'
-      }
+      },
+      storage: 'sessionStorage'
     }, options);
 
+    var storage = window[settings.storage];
 
     const _this = {
       month: '',
@@ -110,9 +112,9 @@
         const ageDate = new Date(ageDifMs); // miliseconds from epoch
         _this.age = Math.abs(ageDate.getUTCFullYear() - 1970);
       },
-      setSessionStorage(key, val) {
+      setStorage(key, val) {
         try {
-          sessionStorage.setItem(key, val);
+          storage.setItem(key, val);
           return true;
         } catch (e) {
           return false;
@@ -148,7 +150,7 @@
       },
     }; // end _this
 
-    if (sessionStorage.getItem('ageVerified') === 'true') {
+    if (storage.getItem('ageVerified') === 'true') {
       return false;
     }
 
@@ -160,8 +162,8 @@
         _this.setAge();
 
         if (_this.age >= settings.minAge) {
-          if (!_this.setSessionStorage('ageVerified', 'true')) {
-            console.log('sessionStorage not supported by your browser');
+          if (!_this.setStorage('ageVerified', 'true')) {
+            console.log(settings.storage + ' not supported by your browser');
           }
           _this.handleSuccess();
         } else {


### PR DESCRIPTION
It's annoying having to re-validate every time I come back to the site.
This allows the user to configure _storage_ as either _sessionStorage_
(the default) or _localStorage_ (which persists beyond the session).